### PR TITLE
remove redundant `raw_root`, move ev definition to code block 3

### DIFF
--- a/environment_variables.py
+++ b/environment_variables.py
@@ -1,5 +1,4 @@
 
 # Directories parameters
-raw_root = r"C:\Users\alexander.lepauvre\Documents\GitHub\bayesian_evidence_accumulation\bids"
 bids_root = r"C:\Users\alexander.lepauvre\Documents\GitHub\bayesian_evidence_accumulation\bids"
 fs_directory = r"C:\Users\alexander.lepauvre\Documents\GitHub\bayesian_evidence_accumulation\bids\derivatives\fs"

--- a/ieeg-data-release.ipynb
+++ b/ieeg-data-release.ipynb
@@ -75,14 +75,7 @@
     "from pipelines.Preprocessing import preprocessing\n",
     "from pipelines.OnsetResponsiveness import onset_responsiveness\n",
     "from pipelines.Decoding import decoding\n",
-    "from HelperFunctions import get_roi_channels, create_mni_montage, get_cmap_rgb_values\n",
-    "\n",
-    "import environment_variables as ev\n",
-    "\n",
-    "# Fetch the fsaverage brain surface to plot the electrodes localization across subjects\n",
-    "fs_average_dir = Path(mne.datasets.sample.data_path(), 'subjects')\n",
-    "# use mne-python's fsaverage data\n",
-    "mne.datasets.fetch_fsaverage(subjects_dir=fs_average_dir, verbose=True)  # downloads if needed"
+    "from HelperFunctions import get_roi_channels, create_mni_montage, get_cmap_rgb_values"
    ]
   },
   {
@@ -140,10 +133,15 @@
     }
    ],
    "source": [
+    "import environment_variables as ev\n",
+    "\n",
+    "# Fetch the fsaverage brain surface to plot the electrodes localization across subjects\n",
+    "fs_average_dir = Path(mne.datasets.sample.data_path(), 'subjects')\n",
+    "# use mne-python's fsaverage data\n",
+    "mne.datasets.fetch_fsaverage(subjects_dir=fs_average_dir, verbose=True)  # downloads if needed\n",
+    "\n",
     "# Print the path to the different data:\n",
     "print(\"The following path are specified\")\n",
-    "print(\"raw data root: \")\n",
-    "print(\"   {}\".format(ev.raw_root))\n",
     "print(\"bids root: \")\n",
     "print(\"   {}\".format(ev.bids_root))\n",
     "print(\"freesurfer directory: \")\n",


### PR DESCRIPTION
1. `raw_root` in `environment_variables.py` seems unecessary since it was only printed once after importation: ![image](https://github.com/Cogitate-consortium/iEEG-data-release/assets/97355086/547eaf38-fb38-4b41-a0c1-3c8fab9d7cbe) Also after talking to Alex I believe the "raw" folder is meant for unprocessed, acquired-as-is data. This according to BIDS should be called "souredata" instead of raw. https://bids-specification.readthedocs.io/en/stable/common-principles.html#source-vs-raw-vs-derived-data
2. It's better to remind users to configure `environment_variables.py` before calling it. Otherwise people might encounter non-existent path error while not knowing what went wrong
